### PR TITLE
[Android] Font size and padding botton of the Subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ var styles = StyleSheet.create({
 * [textTracks](#texttracks)
 * [useTextureView](#usetextureview)
 * [volume](#volume)
+* [fontSizeTrack](#fontSizeTrack)
+* [paddingBottonTrack](#paddingBottonTrack)
 
 ### Event props
 * [onAudioBecomingNoisy](#onaudiobecomingnoisy)
@@ -805,6 +807,19 @@ Adjust the volume.
 
 Platforms: all
 
+#### fontSizeTrack
+Adjust the font size of the subtitles in Android.
+* **Default font size of the device** - The default value for this props
+* **Other values (int)** - Change the font size
+
+Platforms: Android ExoPlayer
+
+#### paddingBottonTrack
+Adjust the padding botton of the subtitles in Android.
+* **0.1 (default)** - Give a padding botton of 0.1
+* **Other values (float)** - Change the padding botton
+
+Platforms: Android ExoPlayer
 
 ### Event props
 

--- a/Video.js
+++ b/Video.js
@@ -435,6 +435,8 @@ Video.propTypes = {
   fullscreenAutorotate: PropTypes.bool,
   fullscreenOrientation: PropTypes.oneOf(['all','landscape','portrait']),
   progressUpdateInterval: PropTypes.number,
+  paddingBottonTrack: PropTypes.number,
+  fontSizeTrack: PropTypes.number,
   useTextureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -84,6 +84,14 @@ public final class ExoPlayerView extends FrameLayout {
         addViewInLayout(layout, 0, aspectRatioParams);
     }
 
+    public void setFontSizeTrack(int fontSizeTrack) {
+        subtitleLayout.setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, fontSizeTrack );
+    }
+
+    public void setPaddingBottonTrack(float paddingBottonTrack) {
+        subtitleLayout.setBottomPaddingFraction(paddingBottonTrack);
+    }
+
     private void setVideoView() {
         if (surfaceView instanceof TextureView) {
             player.setVideoTextureView((TextureView) surfaceView);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1162,4 +1162,12 @@ class ReactExoplayerView extends FrameLayout implements
             removeViewAt(1);
         }
     }
+
+    public void setFontSizeTrack(int fontSizeTrack) {
+        exoPlayerView.setFontSizeTrack(fontSizeTrack);
+    }
+
+    public void setPaddingBottonTrack(float paddingBottonTrack) {
+        exoPlayerView.setPaddingBottonTrack(paddingBottonTrack);
+    }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -59,6 +59,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
+    private static final String PROP_FRONT_SIZE_TRACK = "fontSizeTrack";
+    private static final String PROP_PADDIND_BOTTON_TRACK = "paddingBottonTrack";
 
     @Override
     public String getName() {
@@ -265,6 +267,16 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)
     public void setControls(final ReactExoplayerView videoView, final boolean controls) {
         videoView.setControls(controls);
+    }
+
+    @ReactProp(name = PROP_FRONT_SIZE_TRACK, defaultInt = 30)
+    public void setFontSizeTrack(final ReactExoplayerView videoView, final int fontSizeTrack) {
+        videoView.setFontSizeTrack(fontSizeTrack);
+    }
+
+    @ReactProp(name = PROP_PADDIND_BOTTON_TRACK, defaultFloat = 0.1f)
+    public void setPaddingBottonTrack(final ReactExoplayerView videoView, final float paddingBottonTrack) {
+        videoView.setPaddingBottonTrack(paddingBottonTrack);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -269,7 +269,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
         videoView.setControls(controls);
     }
 
-    @ReactProp(name = PROP_FRONT_SIZE_TRACK, defaultInt = 30)
+    @ReactProp(name = PROP_FRONT_SIZE_TRACK)
     public void setFontSizeTrack(final ReactExoplayerView videoView, final int fontSizeTrack) {
         videoView.setFontSizeTrack(fontSizeTrack);
     }


### PR DESCRIPTION
Fix issue [#1335](https://github.com/react-native-community/react-native-video/issues/1335)

**Font size**

Before the font size of the subtitles was set by default for Android and the default size was really large and looks weird in some devices. It was no possible to set the font size via JavaScript or editing the VTT file. Now with this changes it is possible to set a font size via JavaScrip using the props: fontSizeTrack.  

**Padding botton** 

It seems that in some devices the subtitles were hidden, so with the props paddingBottonTrack is possible to set via JavaScript a padding botton to position better the subtitles in the screen. 
